### PR TITLE
feat!: remove `inheritPropertyInitializers` from `PartialType` (for discussion)

### DIFF
--- a/lib/partial-type.helper.ts
+++ b/lib/partial-type.helper.ts
@@ -2,17 +2,12 @@ import { Type } from '@nestjs/common';
 import { MappedType } from './mapped-type.interface';
 import {
   applyIsOptionalDecorator,
-  inheritPropertyInitializers,
   inheritTransformationMetadata,
   inheritValidationMetadata,
 } from './type-helpers.utils';
 
 export function PartialType<T>(classRef: Type<T>): MappedType<Partial<T>> {
-  abstract class PartialClassType {
-    constructor() {
-      inheritPropertyInitializers(this, classRef);
-    }
-  }
+  abstract class PartialClassType {}
 
   const propertyKeys = inheritValidationMetadata(classRef, PartialClassType);
   inheritTransformationMetadata(classRef, PartialClassType);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#1425](https://github.com/nestjs/graphql/issues/1425)
In this old issue from the graphql repo it is suggested that `PartialType` shouldn't inherit property initializers which makes total sense since a `CreateCatDto` may provide default value for some fields but a `UpdateCatDto` that marks all fields as optional should leave all unset fields undefined to avoid unwanted changes.
We can make this an option but it feels like it should be the default behavior since I can't think of any case where it can be useful.

## What is the new behavior?
`PartialType` doesn't inherit property initializers.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
